### PR TITLE
Add simple portfolio landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# test2
+# Portfolio Landing Page
+
+This repository contains a landing page for Suzanne Sharma's portfolio.
+
+## Live Site
+View the hosted page on GitHub Pages:
+[https://suzannesharma.github.io/portfolio/](https://suzannesharma.github.io/portfolio/)
+
+## Features
+- Hero section with calls to action
+- Sections for expertise, about, portfolio, testimonials and contact
+- Smooth scrolling navigation and auto-updating year
+
+## Usage
+
+Open `index.html` in your browser to view the page.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Suzanne Sharma - Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-p1CmS7VIBfLjC3bXdpFoeQWLh3HTg3eITNijF3xXsgALd0S4AJh9p+7FNFONCwqqZxIBFQ4v13Pu79LzjHpJ0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <nav class="container">
+      <h1 class="logo">Suzanne</h1>
+      <ul class="nav-links">
+        <li><a href="#about">About</a></li>
+        <li><a href="#services">Services</a></li>
+        <li><a href="#portfolio">Portfolio</a></li>
+        <li><a href="#testimonials">Testimonials</a></li>
+        <li><a class="btn" href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <section class="hero" id="home">
+    <div class="container hero-content">
+      <div class="hero-text">
+        <h2>I create <span>product design</span> and <br> brand experience</h2>
+        <p>Designing meaningful experiences for digital products and brands.</p>
+        <a href="https://www.linkedin.com/in/suzanne-sharma-052964218/" class="btn" target="_blank" rel="noopener">LinkedIn</a>
+        <a href="#contact" class="btn btn-outline">Let's chat</a>
+      </div>
+      <div class="hero-image">
+        <img src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=600&q=80" alt="Suzanne Sharma smiling">
+      </div>
+    </div>
+  </section>
+
+  <section id="services" class="services">
+    <div class="container">
+      <h2>My Expertise</h2>
+      <div class="service-items">
+        <div class="service">
+          <i class="fa-solid fa-object-group"></i>
+          <h3>UX &amp; UI Design</h3>
+          <p>Create digital products with unique ideas.</p>
+        </div>
+        <div class="service">
+          <i class="fa-solid fa-mobile-screen-button"></i>
+          <h3>App Design &amp; Development</h3>
+          <p>From prototypes to production ready apps.</p>
+        </div>
+        <div class="service">
+          <i class="fa-solid fa-code"></i>
+          <h3>Web Design &amp; Development</h3>
+          <p>Responsive websites focused on accessibility.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="about" class="about">
+    <div class="container about-content">
+      <div class="about-image">
+        <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=600&q=80" alt="Suzanne Sharma portrait">
+      </div>
+      <div class="about-text">
+        <h2>About Me</h2>
+        <p>I am a product designer with a passion for crafting intuitive experiences. My work spans user research, visual design and front‑end development.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="portfolio" class="portfolio">
+    <div class="container">
+      <h2>My Portfolio</h2>
+      <div class="portfolio-items">
+        <div class="portfolio-item">
+          <img src="https://picsum.photos/seed/p1/400/300" alt="Project one screenshot">
+          <h3>Project One</h3>
+        </div>
+        <div class="portfolio-item">
+          <img src="https://picsum.photos/seed/p2/400/300" alt="Project two screenshot">
+          <h3>Project Two</h3>
+        </div>
+        <div class="portfolio-item">
+          <img src="https://picsum.photos/seed/p3/400/300" alt="Project three screenshot">
+          <h3>Project Three</h3>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="testimonials" class="testimonials">
+    <div class="container">
+      <h2>Customer Testimonials</h2>
+      <div class="testimonial-items">
+        <div class="testimonial">
+          <p>"Suzanne delivered exceptional designs that captured our brand."</p>
+          <div class="stars">
+            <i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i>
+          </div>
+        </div>
+        <div class="testimonial">
+          <p>"Great communication and attention to detail throughout the project."</p>
+          <div class="stars">
+            <i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i>
+          </div>
+        </div>
+        <div class="testimonial">
+          <p>"The final product exceeded our expectations."</p>
+          <div class="stars">
+            <i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star"></i><i class="fa-solid fa-star-half-stroke"></i>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="contact" class="contact">
+    <div class="container">
+      <h2>Contact Me</h2>
+      <form>
+        <input type="text" placeholder="Full Name" required>
+        <input type="email" placeholder="Email Address" required>
+        <textarea rows="5" placeholder="Message" required></textarea>
+        <button type="submit" class="btn">Send Message</button>
+      </form>
+    </div>
+  </section>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Suzanne Sharma</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>
+

--- a/script.js
+++ b/script.js
@@ -1,0 +1,23 @@
+document.getElementById('year').textContent = new Date().getFullYear();
+
+// Smooth scrolling for anchor links
+document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+  anchor.addEventListener('click', function (e) {
+    const target = document.querySelector(this.getAttribute('href'));
+    if (target) {
+      e.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
+});
+
+// Simple contact form handler
+const contactForm = document.querySelector('.contact form');
+if (contactForm) {
+  contactForm.addEventListener('submit', e => {
+    e.preventDefault();
+    alert('Thank you for your message!');
+    contactForm.reset();
+  });
+}
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,263 @@
+:root {
+  --primary: #5e3bee;
+  --bg: #f8f8ff;
+  --text: #333;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  color: var(--text);
+  line-height: 1.6;
+  background: #fff;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(90%, 1200px);
+  margin: auto;
+}
+
+/* Header */
+header {
+  background: #fff;
+  border-bottom: 1px solid #eee;
+}
+
+nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+.logo {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  text-decoration: none;
+  color: var(--text);
+}
+
+.nav-links .btn {
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  background: var(--primary);
+  color: #fff;
+}
+
+/* Buttons */
+.btn {
+  display: inline-block;
+  background: var(--primary);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--primary);
+  border: 2px solid var(--primary);
+}
+
+/* Hero */
+.hero {
+  background: var(--bg);
+  padding: 6rem 0;
+}
+
+.hero-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.hero-text {
+  flex: 1 1 400px;
+}
+
+.hero-text h2 {
+  font-size: 2.5rem;
+  line-height: 1.2;
+}
+
+.hero-text h2 span {
+  color: var(--primary);
+}
+
+.hero-image {
+  flex: 1 1 300px;
+  text-align: center;
+}
+
+.hero-image img {
+  border-radius: 50%;
+}
+
+/* Services */
+.services {
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.service-items {
+  margin-top: 2rem;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.service {
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 2rem;
+  flex: 1 1 250px;
+}
+
+.service i {
+  font-size: 2rem;
+  color: var(--primary);
+  margin-bottom: 1rem;
+}
+
+/* About */
+.about {
+  background: var(--bg);
+  padding: 4rem 0;
+}
+
+.about-content {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.about-image,
+.about-text {
+  flex: 1 1 300px;
+}
+
+.about-image img {
+  border-radius: 8px;
+}
+
+/* Portfolio */
+.portfolio {
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.portfolio-items {
+  margin-top: 2rem;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.portfolio-item {
+  flex: 1 1 300px;
+}
+
+.portfolio-item img {
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+}
+
+/* Testimonials */
+.testimonials {
+  background: var(--bg);
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.testimonial-items {
+  margin-top: 2rem;
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.testimonial {
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 2rem;
+  flex: 1 1 250px;
+}
+
+.stars {
+  color: #f5b301;
+  margin-top: 1rem;
+}
+
+/* Contact */
+.contact {
+  padding: 4rem 0;
+  text-align: center;
+}
+
+.contact form {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.contact input,
+.contact textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  padding: 1.5rem 0;
+  background: #333;
+  color: #fff;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .hero-text h2 {
+    font-size: 2rem;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+}
+


### PR DESCRIPTION
## Summary
- redesign landing page with hero, expertise, about, portfolio, testimonials and contact sections
- add responsive styling and color theme
- enhance JS with smooth scrolling and contact form handler
- update README with feature overview and link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f193d33f083259ee39aaccfe4e81f